### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+# Change Log
+
+# 0.2.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Pack which allows integration with different Google services.
 
+## Configuration
+
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Actions
 
 * ``get_search_results`` - Retrieve Google search results for the provided

--- a/actions/get_search_results.yaml
+++ b/actions/get_search_results.yaml
@@ -1,6 +1,6 @@
 ---
   name: "get_search_results"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Retrieve Google search results for the provided query."
   enabled: true
   entry_point: "get_search_results.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ description : st2 content pack containing google integrations
 keywords:
   - google
   - search
-version : 0.1.1
+version : 0.2.0
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.